### PR TITLE
Use ace 01.08.2014 (works better with Safari)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -100,7 +100,7 @@ object Build extends sbt.Build{
         "org.scala-lang.modules" %% "scala-async" % "0.9.1" % "provided",
         "com.scalatags" %% "scalatags" % "0.3.8",
         "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided",
-        "org.webjars" % "ace" % "07.31.2013",
+        "org.webjars" % "ace" % "01.08.2014",
         "org.webjars" % "jquery" % "2.1.0-2",
         "org.webjars" % "normalize.css" % "2.1.3",
         "com.lihaoyi" %% "upickle" % "0.1.4",

--- a/server/src/main/scala/fiddle/Static.scala
+++ b/server/src/main/scala/fiddle/Static.scala
@@ -4,11 +4,11 @@ import scalatags.Text.all._
 import scalatags.Text.tags2
 object Static{
   val aceFiles = Seq(
-    "/META-INF/resources/webjars/ace/07.31.2013/src-min/ace.js",
-    "/META-INF/resources/webjars/ace/07.31.2013/src-min/ext-language_tools.js",
-    "/META-INF/resources/webjars/ace/07.31.2013/src-min/ext-static_highlight.js",
-    "/META-INF/resources/webjars/ace/07.31.2013/src-min/mode-scala.js",
-    "/META-INF/resources/webjars/ace/07.31.2013/src-min/theme-twilight.js"
+    "/META-INF/resources/webjars/ace/01.08.2014/src-min/ace.js",
+    "/META-INF/resources/webjars/ace/01.08.2014/src-min/ext-language_tools.js",
+    "/META-INF/resources/webjars/ace/01.08.2014/src-min/ext-static_highlight.js",
+    "/META-INF/resources/webjars/ace/01.08.2014/src-min/mode-scala.js",
+    "/META-INF/resources/webjars/ace/01.08.2014/src-min/theme-twilight.js"
   )
 
   def page(arg: String, srcFiles: Seq[String], source: String = "", compiled: String = "", analytics: Boolean = true) =


### PR DESCRIPTION
The older version of ace has problems with cursor positioning as described in [ace #1534](https://github.com/ajaxorg/ace/issues/1534).
