### PR TITLE
Allow publishing via Docker.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.ensime_lucene
+.idea
+.worksheet
+.settings
+bin
+.git
+target
+project/target
+project/project/target
+tmp
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM nightscape/docker-sbt
+
+COPY project/build.properties project/*.sbt project/*.scala /app/project/
+WORKDIR /app
+RUN sbt "; update ; compile"
+
+COPY . /app/
+RUN sbt stage
+
+CMD ["/app/server/target/universal/stage/bin/server"]
+EXPOSE 8080

--- a/readme.md
+++ b/readme.md
@@ -25,4 +25,9 @@ To package as a fat jar and run, or
 capstan build -p vmw; capstan run -p vmw
 ```
 
-To bundle as an image using OSv and run it under VMware.
+To bundle as an image using OSv and run it under VMware, or
+
+```
+docker build -t scala-js-fiddle . ; docker run -p 8080:8080 scala-js-fiddle:latest
+```
+To bundle as a Docker image and run it in a Docker container.

--- a/shared/Shared.scala
+++ b/shared/Shared.scala
@@ -24,7 +24,7 @@ object Shared{
 
   val gistId = "9443f8e0ecc68d1058ad"
 
-  val url = "http://www.scala-js-fiddle.com"
+  val url = ""
 //  val url = "http://localhost:8080"
 }
 


### PR DESCRIPTION
Hi Li Haoyi,

I added an SBT-based Dockerfile for Docker publishing.
I could decrease image size by building the JAR outside of Docker and then using a bare Java image, but for development and testing out stuff it's easier if SBT is included.
Note that I used an "" as server URL as per [#13](https://github.com/lihaoyi/scala-js-fiddle/issues/13) but I could take that line out if it causes trouble in another place.
